### PR TITLE
Update version to achieve our purposes

### DIFF
--- a/ruby/yapay_gw/yapay_gw.gemspec
+++ b/ruby/yapay_gw/yapay_gw.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.5.1"
+  spec.required_ruby_version = ">= 2.3.3"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
In our integration with Zenon, we need the Yapay's gem to use the version 2.3.3 of Ruby. It's the one we use in our project, and unfortunately we can't update it right now.